### PR TITLE
Merge pull request #12 from evanrolfe/fix/issue_11_start_server

### DIFF
--- a/setup-dev.js
+++ b/setup-dev.js
@@ -2,12 +2,8 @@ require('ts-node/register');
 
 const { promisify } = require('util');
 const path = require('path');
-const os = require('os');
 const fs = require('fs');
-const rimraf = require('rimraf');
 
-const canAccess = (file) => promisify(fs.access)(file).then(() => true).catch(() => false);
-const deleteDir = promisify(rimraf);
 const mkdir = promisify(fs.mkdir);
 const writeFile = promisify(fs.writeFile);
 const chmod = promisify(fs.chmod);
@@ -20,20 +16,14 @@ setInterval(() => {}, 999999999);
 // This lets us edit both and the desktop together. We do this by creating a fake server,
 // which doesn't exit, but otherwise does nothing.
 async function setUpDevEnv() {
-    const serverFolder = path.join(__dirname, 'httptoolkit-server');
-    const serverExists = await canAccess(serverFolder);
-    if (serverExists) {
-        await deleteDir(serverFolder);
+    const serverBinFolder = path.join(__dirname, 'httptoolkit-server', 'bin');
+    await mkdir(serverBinFolder, { recursive: true });
 
-        const binFolder = path.join(serverFolder, 'bin');
-        await mkdir(binFolder, { recursive: true });
-
-        const bins = ['httptoolkit-server', 'httptoolkit-server.cmd'].map((bin) => path.join(binFolder, bin));
-        await Promise.all(bins.map(async (bin) => {
-            await writeFile(bin, sleepForeverScript);
-            await chmod(bin, 0o755);
-        }));
-    }
+    const bins = ['httptoolkit-server', 'httptoolkit-server.cmd'].map((bin) => path.join(serverBinFolder, bin));
+    await Promise.all(bins.map(async (bin) => {
+        await writeFile(bin, sleepForeverScript);
+        await chmod(bin, 0o755);
+    }));
 }
 
 setUpDevEnv().catch(e => {

--- a/setup-dev.js
+++ b/setup-dev.js
@@ -2,8 +2,12 @@ require('ts-node/register');
 
 const { promisify } = require('util');
 const path = require('path');
+const os = require('os');
 const fs = require('fs');
+const rimraf = require('rimraf');
 
+const canAccess = (file) => promisify(fs.access)(file).then(() => true).catch(() => false);
+const deleteDir = promisify(rimraf);
 const mkdir = promisify(fs.mkdir);
 const writeFile = promisify(fs.writeFile);
 const chmod = promisify(fs.chmod);
@@ -16,10 +20,15 @@ setInterval(() => {}, 999999999);
 // This lets us edit both and the desktop together. We do this by creating a fake server,
 // which doesn't exit, but otherwise does nothing.
 async function setUpDevEnv() {
-    const serverBinFolder = path.join(__dirname, 'httptoolkit-server', 'bin');
-    await mkdir(serverBinFolder, { recursive: true });
+    const serverFolder = path.join(__dirname, 'httptoolkit-server');
+    const serverExists = await canAccess(serverFolder);
 
-    const bins = ['httptoolkit-server', 'httptoolkit-server.cmd'].map((bin) => path.join(serverBinFolder, bin));
+    if (serverExists) await deleteDir(serverFolder);
+
+    const binFolder = path.join(serverFolder, 'bin');
+    await mkdir(binFolder, { recursive: true });
+
+    const bins = ['httptoolkit-server', 'httptoolkit-server.cmd'].map((bin) => path.join(binFolder, bin));
     await Promise.all(bins.map(async (bin) => {
         await writeFile(bin, sleepForeverScript);
         await chmod(bin, 0o755);


### PR DESCRIPTION
Does this fix seem ok to you? It now works regardless of whether or not you have the httptoolkit-server folder in the project root. I also got rid of the `rm -rf` delete because it seemed like quite an aggressive command to run without giving the user any warning and I didn't see why it was necessary to delete the entire folder if we just want to write a couple bin files? I might not know the full story though?