### PR TITLE
Support using the native file open dialog

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import { promisify } from 'util';
 import * as querystring from 'querystring';
 import { URL } from 'url';
-import { app, BrowserWindow, shell, Menu, dialog, session } from 'electron';
+import { app, BrowserWindow, shell, Menu, dialog, session, ipcMain } from 'electron';
 import * as uuid from 'uuid/v4';
 import * as yargs from 'yargs';
 import * as semver from 'semver';
@@ -77,6 +77,7 @@ const createWindow = (logStream: WriteStream) => {
         height: windowState.height,
 
         webPreferences: {
+            preload: path.join(__dirname, 'preload.js'),
             contextIsolation: true,
             nodeIntegration: false
         },
@@ -584,3 +585,11 @@ if (!amMainInstance) {
         }
     });
 }
+
+ipcMain.handle(
+  'open-file',
+  () =>
+    dialog.showOpenDialogSync({
+      properties: ['openFile', 'treatPackageAsDirectory'],
+    })?.[0]
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -587,7 +587,7 @@ if (!amMainInstance) {
 }
 
 ipcMain.handle(
-  'open-file',
+  'select-application',
   () =>
     dialog.showOpenDialogSync({
       properties: ['openFile', 'treatPackageAsDirectory'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -590,6 +590,9 @@ ipcMain.handle(
   'select-application',
   () =>
     dialog.showOpenDialogSync({
-      properties: ['openFile', 'treatPackageAsDirectory'],
+      properties:
+        process.platform === 'darwin'
+          ? ['openFile', 'openDirectory', 'treatPackageAsDirectory']
+          : ['openFile'],
     })?.[0]
 );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,0 +1,5 @@
+import {contextBridge, ipcRenderer} from 'electron';
+
+contextBridge.exposeInMainWorld('nativeFile', {
+  open: () => ipcRenderer.invoke('open-file'),
+});

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,5 +1,5 @@
 import {contextBridge, ipcRenderer} from 'electron';
 
-contextBridge.exposeInMainWorld('nativeFile', {
-  open: () => ipcRenderer.invoke('open-file'),
+contextBridge.exposeInMainWorld('desktopApi', {
+  selectApplication: () => ipcRenderer.invoke('select-application'),
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     },
     "include": [
         "./src/index.ts",
+        "./src/preload.ts",
         "./custom-typings/**/*.d.ts"
     ]
 }


### PR DESCRIPTION
Required for Electron apps on macOS. httptoolkit/httptoolkit#329