### PR TITLE
Fix POSTUN scriptlet on RPM upgrade and uninstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
       ]
     },
     "rpm": {
-      "artifactName": "HttpToolkit-${version}.rpm"
+      "artifactName": "HttpToolkit-${version}.rpm",
+      "afterRemove": "scripts/post-uninstall-rpm.sh"
     },
     "appImage": {
       "artifactName": "HttpToolkit-${version}.AppImage"

--- a/scripts/post-uninstall-rpm.sh
+++ b/scripts/post-uninstall-rpm.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This check works only for RPMs
+if [ $1 -ge 1 ]; then
+    # Package upgrade, do not uninstall
+    exit 0
+fi
+
+# Delete the link to the binary
+if type update-alternatives >/dev/null 2>&1; then
+    update-alternatives --remove "httptoolkit" "/opt/HTTP Toolkit/httptoolkit"
+else
+    rm -f "/usr/bin/httptoolkit"
+fi


### PR DESCRIPTION
As mentioned in https://github.com/httptoolkit/httptoolkit-website/pull/85#issuecomment-2458527452, upgrading or uninstalling the HttpToolkit RPM package produces the same messages as in this issue: IsmaelMartinez/teams-for-linux#958.

I was curious how other projects addressed this problem and stumbled upon https://github.com/pulsar-edit/pulsar/commit/a47da8e3e0627fe242226fb37ce3586999d69fc9. I combined Pulsar's upgrade check with the POSTUN scriptlet produced by electron-builder to create a custom post-uninstall script for RPM packages.

I tested the fix on Fedora 40 by
1. building two RPM packages with increasing version numbers
2. installing the package with the lower version number, then upgrading to the package with the higher version number
3. uninstalling the latter package

All of these actions succeeded without any issues. Upgrading does not remove the symlink from `/usr/bin/httptoolkit` to `/opt/HTTP Toolkit/httptoolkit`. Removing the package removes the `/usr/bin/httptoolkit` symlink as expected.