### PR TITLE
Update WinGet workflow to remove inline `--token` usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           $installerUrl = "https://github.com/httptoolkit/httptoolkit-desktop/releases/download/v$packageVersion/HttpToolkit-$packageVersion.exe"
 
           # Update package using wingetcreate
-          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
           .\wingetcreate.exe update HTTPToolKit.HTTPToolKit `
             --version $packageVersion `
             --urls "$installerUrl|x64" `

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,10 @@ jobs:
           gh repo sync "$forkOwner/winget-pkgs" --source microsoft/winget-pkgs
 
       - name: Submit package using wingetcreate
+        # winget-create will read the following environment variable to access the GitHub token needed for submitting a PR
+        # See https://aka.ms/winget-create-token
+        env:
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
         run: |
           $packageVersion = "${{ github.ref }}" -replace 'refs/tags/v', ''
           $installerUrl = "https://github.com/httptoolkit/httptoolkit-desktop/releases/download/v$packageVersion/HttpToolkit-$packageVersion.exe"
@@ -220,5 +224,4 @@ jobs:
           .\wingetcreate.exe update HTTPToolKit.HTTPToolKit `
             --version $packageVersion `
             --urls "$installerUrl|x64" `
-            --submit `
-            --token "${{ secrets.WINGET_GITHUB_TOKEN }}"
+            --submit


### PR DESCRIPTION
## Change

Removes the inline `--token` usage as per latest recommendation at https://github.com/microsoft/winget-create/blob/main/doc/token.md#usage

Switches to the use of environment variable instead.

Somewhat subjective, but I also switch to use `curl` instead of Powershell `Invoke-WebRequest` for speed